### PR TITLE
Change GeoTiff output driver to COG.

### DIFF
--- a/src/eocis_chuk_api/chuk_dataset_utils.py
+++ b/src/eocis_chuk_api/chuk_dataset_utils.py
@@ -489,7 +489,7 @@ class CHUKDataSetUtils:
             # this seems to cause a problem, why?
             del ds_crs[variable_name].attrs["grid_mapping"]
         tags = CHUKMetadata.to_json(ds_crs, variable_name)
-        ds_crs[variable_name].rio.to_raster(to_path, tags=tags)
+        ds_crs[variable_name].rio.to_raster(to_path, tags=tags, driver="COG")
 
     def __extend_attrs(self, attrs, key, value, required=None):
         if required and value == "" or value is None:


### PR DESCRIPTION
Setting as Cloud Optimised GeoTiff saves as a GeoTiff but with flags for compression and tiling so outputs require less storage space and are more efficient to use.

For my use case reduced file size from ~ 600 MB to 10 - 60 MB.

Due to the space saving I think it is sensible to make this the default.